### PR TITLE
Add better errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem "better_errors"
+  gem "binding_of_caller"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,13 @@ GEM
     autoprefixer-rails (9.7.6)
       execjs
     bcrypt (3.1.13)
+    better_errors (2.7.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
     bindex (0.8.1)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -68,6 +74,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
+    debug_inspector (0.0.3)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -206,6 +213,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   bootsnap (>= 1.4.2)
   byebug
   chartkick

--- a/config/database.yml
+++ b/config/database.yml
@@ -58,6 +58,7 @@ development:
 test:
   <<: *default
   database: DevOfWeeks_test
+  url: <%= ENV['DATABASE_URL'] %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,3 +60,4 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end
+BetterErrors::Middleware.allow_ip! "0.0.0.0/0"


### PR DESCRIPTION
This adds the better errors gem which gives you a nice interface from the browser including a repl.

https://github.com/BetterErrors/better_errors

I also snuck in a fix for creating db on initial creation of db.

Note: you will have to rebuild

```
docker-compose down
docker-compose build
```
Try doing something that would cause an error in a controller and see the better_errors interface.
