### PR TITLE
Fix webpacker development for websockets and help for byebug.

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -61,7 +61,7 @@ development:
     https: false
     host: webpacker
     port: 3035
-    public: webpacker:3035
+    public: localhost:3035
     hmr: false
     # Inline should be set to true if using HMR
     inline: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - REDIS_URL=redis://redis:6379
       - DATABASE_URL=postgres://postgres@db:5432/DevOfWeeks_development
       - PORT=3000
+      - TERM=dumb
     build:
       context: .
       dockerfile: ./docker/DockerFile

--- a/server_start.sh
+++ b/server_start.sh
@@ -1,0 +1,4 @@
+echo "Good luck comrade.";
+docker-compose up -d && sleep 5 && docker attach $(docker-compose ps -q dow_app)
+
+echo "Goodbye comrade.";


### PR DESCRIPTION

This fixes websockets. 
The internal webpacker needs to point to the webpacker dns service, but the browser needs to point to localhost.

This also adds a shell script so you can start your server with ./start_server.sh, this helps because you can use bye_bug while attached to the docker image.

Lastly this adds this to the env:
```
      - TERM=dumb
```

This fixes an issue with docker and byebug.

